### PR TITLE
[IBCDPE-387]/agora-data-tools wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,129 +1,18 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
+# Nextflow log files
+work/
+.nextflow*
 
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
+# files for testing
+*.ipynb
 .ipynb_checkpoints
 
-# IPython
-profile_default/
-ipython_config.py
+#cache
+__pycache__/
 
-# pyenv
-.python-version
+#
+*.DS_Store
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
+#example files
+*.ome.tiff
+*.ome.tif
+*.txt

--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@ nextflow.enable.dsl = 2
 process AGORA_DATA_RUN {
 
 
-    container "sagebionetworks/agora-data-tools"
+    container "sagebionetworks/agora-data-tools:latest"
 
     secret "SYNAPSE_AUTH_TOKEN"
 

--- a/main.nf
+++ b/main.nf
@@ -2,10 +2,12 @@
 nextflow.enable.dsl = 2
 
 //test params
-params.config = "test.config.yaml"
+params.config = "/agora-data-tools/test_config.yaml"
 
 //runs test config for Agora
 process AGORA_DATA_RUN {
+
+    debug true
 
     container "sagebionetworks/agora-data-tools"
 
@@ -16,10 +18,12 @@ process AGORA_DATA_RUN {
 
     script:
     """
-    python ./agoradatatools/process.py ${config}
+    python /agora-data-tools/agoradatatools/process.py ${config}
     """
 
 }
+
+
 
 workflow{
 

--- a/main.nf
+++ b/main.nf
@@ -1,9 +1,6 @@
 // Ensure DSL2
 nextflow.enable.dsl = 2
 
-//test params
-params.config = "/agora-data-tools/test_config.yaml"
-
 //runs test config for Agora
 process AGORA_DATA_RUN {
 
@@ -14,7 +11,7 @@ process AGORA_DATA_RUN {
     secret "SYNAPSE_AUTH_TOKEN"
 
     input:
-    val(config)
+    path(config)
 
     script:
     """

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,6 @@ nextflow.enable.dsl = 2
 //runs test config for Agora
 process AGORA_DATA_RUN {
 
-    debug true
 
     container "sagebionetworks/agora-data-tools"
 

--- a/main.nf
+++ b/main.nf
@@ -1,0 +1,28 @@
+// Ensure DSL2
+nextflow.enable.dsl = 2
+
+//test params
+params.config = "test.config.yaml"
+
+//runs test config for Agora
+process AGORA_DATA_RUN {
+
+    container "sagebionetworks/agora-data-tools"
+
+    secret "SYNAPSE_AUTH_TOKEN"
+
+    input:
+    val(config)
+
+    script:
+    """
+    python ./agoradatatools/process.py ${config}
+    """
+
+}
+
+workflow{
+
+    AGORA_DATA_RUN(params.config)
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,13 @@
+// Profiles
+profiles {
+
+    docker {
+        docker.enabled         = true
+        docker.userEmulation   = true
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,4 +10,16 @@ profiles {
         charliecloud.enabled   = false
     }
 
+    test {
+        params {
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/dev/test_config.yaml"
+        }
+    }
+
+    debug {
+        process {
+            debug = true
+        }
+    }
+
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 // Profiles
 executor {
-    memory = '32 GB'
+    memory = '64 GB'
     cpus = 8
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,9 @@
 // Profiles
+executor {
+    memory = '32 GB'
+    cpus = 8
+}
+
 profiles {
 
     docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,7 +1,8 @@
 // Profiles
-executor {
-    memory = '64 GB'
-    cpus = 8
+
+process {
+    memory = { 32.GB * task.attempt }
+    cpus = 8 
 }
 
 profiles {


### PR DESCRIPTION
This PR adds main.nf and nextflow.config for the Nextflow workflow that wraps `agora-data-tools`. The workflow has been tested successfully in Ubuntu EC2, but failed when testing on Tower with the following error:

`  Command 'ps' required by nextflow to collect task metrics cannot be found`

After initial research, it seems like the problem might be that this Docker container is missing a package called `procps` as in this [issue](https://github.com/replikation/What_the_Phage/issues/89)