### PR TITLE
[IBCDPE-386] Update to use GHCR container

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,7 @@ nextflow.enable.dsl = 2
 process AGORA_DATA_RUN {
 
 
-    container "sagebionetworks/agora-data-tools:latest"
+    container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
 
     secret "SYNAPSE_AUTH_TOKEN"
 


### PR DESCRIPTION
This PR swaps out the docker container used in `AGORA_DATA_RUN` to use our new GHCR container created as part of [this](https://github.com/Sage-Bionetworks/agora-data-tools/pull/92) PR. We will continue to use the `latest` tag so that we are always using the most up-to-date version of `agora-data-tools` when we run this workflow.