### PR TITLE
[IBCDPE-946] Updates Command With `upload` Flag

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -14,7 +14,7 @@ process AGORA_DATA_RUN {
 
     script:
     """
-    adt ${config}
+    adt ${config} --upload --platform NEXTFLOW
     """
 
 }


### PR DESCRIPTION
This PR updates the command we use to take advantage of the new `upload` and `platform` flags added [here](https://github.com/Sage-Bionetworks/agora-data-tools/pull/133). This will need to be merged after the new container image is published.