### PR TITLE
[IBCDPE-947] Adds `run_id` to cli command

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,6 @@ nextflow.enable.dsl = 2
 
 //runs test config for Agora
 process AGORA_DATA_RUN {
-    debug = true
 
     container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
 

--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,7 @@ nextflow.enable.dsl = 2
 
 //runs test config for Agora
 process AGORA_DATA_RUN {
-
+    debug = true
 
     container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
 
@@ -14,7 +14,7 @@ process AGORA_DATA_RUN {
 
     script:
     """
-    adt ${config} --upload --platform NEXTFLOW
+    adt ${config} --upload --platform NEXTFLOW --run_id ${workflow.runName}
     """
 
 }


### PR DESCRIPTION
This PR adds the new `run_id` parameter to the command run in `nf-agora`. This will not be merged until the new version of `agora-data-tools` is released after this [PR](https://github.com/Sage-Bionetworks/agora-data-tools/pull/135) is merged.