### PR TITLE
[AG-1558] Adds `modelad` Profiles

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,18 @@ profiles {
         }
     }
 
+    modelad_test {
+        params {
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/dev/modelad_test_config.yaml"
+        }
+    }
+
+    modelad_prod {
+        params {
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/dev/modelad_config.yaml"
+        }
+    }
+
 
     debug {
         process {


### PR DESCRIPTION
This PR adds the `modelad_test` and `modelad_prod` profiles to the Nextflow Workflow for ease of running the Model-AD pipeline. 

**Notes:**
- `modelad_test` uses the `modelad_test_config.yaml` file (tested in [this](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/agora-project/watch/3rjH7Y1NFnyG6C) Seqera Platform run)
- `modelad_prod` points to the currently nonexistent `modelad_config.yaml` file (if used at present, it will fail)
     - This was requested by the users of this workflow so that it is ready to be used once this configuration file is added 
