### PR TITLE
[AG-2137] added task parallelization, changed default error strategy, used different memory for large datasets 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -7,7 +7,7 @@ process AGORA_DATA_RUN {
 
     secret "SYNAPSE_AUTH_TOKEN"
 
-    memory { ['rna_de_individual', 'rna_de_aggregate'].contains(dataset) ? 64.GB * task.attempt : 5.GB * task.attempt }
+    memory { ['rna_de_individual', 'rna_de_aggregate'].contains(dataset) ? 64.GB * task.attempt : 32.GB * task.attempt }
     //make sure other tasks can finish when one task fails
     errorStrategy 'finish'
 

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl = 2
 //runs test config for Agora
 process AGORA_DATA_RUN {
 
-    container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
+    container "ghcr.io/sage-bionetworks/agora-data-tools:ag-2122-combined"
 
     secret "SYNAPSE_AUTH_TOKEN"
 

--- a/main.nf
+++ b/main.nf
@@ -1,29 +1,40 @@
 // Ensure DSL2
 nextflow.enable.dsl = 2
 
-//runs test config for Agora
+import org.yaml.snakeyaml.Yaml
+
+def LARGE_MEMORY_DATASETS = ['rna_de_individual', 'rna_de_aggregate']
+
 process AGORA_DATA_RUN {
 
     container "ghcr.io/sage-bionetworks/agora-data-tools:ag-2122-combined"
 
     secret "SYNAPSE_AUTH_TOKEN"
 
+    memory { LARGE_MEMORY_DATASETS.contains(dataset) ? 64.GB * task.attempt : 32.GB * task.attempt }
+
     input:
     path(config)
     val dataset
 
     script:
-    def datasetFlag = dataset ? "--dataset '${dataset}'" : ''
     """
-    adt ${config} --upload --platform NEXTFLOW --run_id ${workflow.runName} ${datasetFlag}
+    adt ${config} --upload --platform NEXTFLOW --run_id ${workflow.runName} --dataset '${dataset}'
     """
 
 }
 
 
 
-workflow{
+workflow {
 
-    AGORA_DATA_RUN(params.config, params.dataset)
+    if (params.dataset) {
+        datasets_ch = Channel.of(params.dataset)
+    } else {
+        def yaml = new Yaml().load(new URL(params.config).text)
+        datasets_ch = Channel.from(yaml.datasets.collect { it.keySet().first() })
+    }
+
+    AGORA_DATA_RUN(params.config, datasets_ch)
 
 }

--- a/main.nf
+++ b/main.nf
@@ -34,12 +34,12 @@ workflow {
 
     if (params.dataset) {
         // split comma-separated dataset names (handles optional spaces) into separate channel items
-        datasets_ch = Channel.of(params.dataset.split(',\\s*'))
+        datasets_ch = Channel.fromList(params.dataset.split(',\\s*'))
     } else {
         // fetch and parse the YAML config file
         def yaml = new Yaml().load(new URL(params.config).text)
         // extract each dataset name and emit as separate channel items
-        datasets_ch = Channel.from(yaml.datasets.collect { it.keySet().first() })
+        datasets_ch = Channel.fromList(yaml.datasets.collect { it.keySet().first() })
     }
 
     AGORA_DATA_RUN(params.config, datasets_ch)

--- a/main.nf
+++ b/main.nf
@@ -3,6 +3,8 @@ nextflow.enable.dsl = 2
 
 process AGORA_DATA_RUN {
 
+    tag "$dataset"
+
     container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
 
     secret "SYNAPSE_AUTH_TOKEN"

--- a/main.nf
+++ b/main.nf
@@ -12,6 +12,8 @@ process AGORA_DATA_RUN {
     secret "SYNAPSE_AUTH_TOKEN"
 
     memory { LARGE_MEMORY_DATASETS.contains(dataset) ? 64.GB * task.attempt : 32.GB * task.attempt }
+    //make sure other tasks can finish when one task fails
+    errorStrategy 'finish'
 
     input:
     path(config)

--- a/main.nf
+++ b/main.nf
@@ -1,17 +1,13 @@
 // Ensure DSL2
 nextflow.enable.dsl = 2
 
-import org.yaml.snakeyaml.Yaml
-
-def LARGE_MEMORY_DATASETS = ['rna_de_individual', 'rna_de_aggregate']
-
 process AGORA_DATA_RUN {
 
     container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
 
     secret "SYNAPSE_AUTH_TOKEN"
 
-    memory { LARGE_MEMORY_DATASETS.contains(dataset) ? 64.GB * task.attempt : 32.GB * task.attempt }
+    memory { ['rna_de_individual', 'rna_de_aggregate'].contains(dataset) ? 64.GB * task.attempt : 5.GB * task.attempt }
     //make sure other tasks can finish when one task fails
     errorStrategy 'finish'
 
@@ -34,10 +30,10 @@ workflow {
 
     if (params.dataset) {
         // split comma-separated dataset names (handles optional spaces) into separate channel items
-        datasets_ch = Channel.fromList(params.dataset.split(',\\s*'))
+        datasets_ch = Channel.fromList(params.dataset.split(',\\s*').toList())
     } else {
         // fetch and parse the YAML config file
-        def yaml = new Yaml().load(new URL(params.config).text)
+        def yaml = new org.yaml.snakeyaml.Yaml().load(new URL(params.config).text)
         // extract each dataset name and emit as separate channel items
         datasets_ch = Channel.fromList(yaml.datasets.collect { it.keySet().first() })
     }

--- a/main.nf
+++ b/main.nf
@@ -7,7 +7,7 @@ def LARGE_MEMORY_DATASETS = ['rna_de_individual', 'rna_de_aggregate']
 
 process AGORA_DATA_RUN {
 
-    container "ghcr.io/sage-bionetworks/agora-data-tools:ag-2122-combined"
+    container "ghcr.io/sage-bionetworks/agora-data-tools:latest"
 
     secret "SYNAPSE_AUTH_TOKEN"
 

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,14 @@ process AGORA_DATA_RUN {
 
     secret "SYNAPSE_AUTH_TOKEN"
 
-    memory { params.large_memory_datasets.split(',').contains(dataset) ? params.large_memory_gb.GB * task.attempt : params.default_memory_gb.GB * task.attempt }
+    // allocate more memory for known large datasets
+    memory {
+        def largeDatasets = params.large_memory_datasets ? params.large_memory_datasets.split(',') : []
+        def mem = largeDatasets.contains(dataset) ? params.large_memory_gb.GB * task.attempt : params.default_memory_gb.GB * task.attempt
+        mem
+    }
+
+
     //make sure other tasks can finish when one task fails
     errorStrategy 'finish'
 
@@ -32,13 +39,15 @@ workflow {
 
     if (params.dataset) {
         // split comma-separated dataset names (handles optional spaces) into separate channel items
-        datasets_ch = Channel.fromList(params.dataset.split(',\\s*').toList())
+        datasets_ch = Channel.fromList(params.dataset.split(',\\s*').toList().toUnique())
     } else {
         // fetch and parse the YAML config file
         def yaml = new org.yaml.snakeyaml.Yaml().load(new URL(params.config).text)
         // extract each dataset name and emit as separate channel items
         datasets_ch = Channel.fromList(yaml.datasets.collect { it.keySet().first() })
     }
+
+    datasets_ch.view { "Dataset: $it" }
 
     AGORA_DATA_RUN(params.config, datasets_ch)
 

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@ process AGORA_DATA_RUN {
 
     secret "SYNAPSE_AUTH_TOKEN"
 
-    memory { ['rna_de_individual', 'rna_de_aggregate'].contains(dataset) ? 64.GB * task.attempt : 32.GB * task.attempt }
+    memory { params.large_memory_datasets.split(',').contains(dataset) ? params.large_memory_gb.GB * task.attempt : params.default_memory_gb.GB * task.attempt }
     //make sure other tasks can finish when one task fails
     errorStrategy 'finish'
 

--- a/main.nf
+++ b/main.nf
@@ -20,8 +20,10 @@ process AGORA_DATA_RUN {
     val dataset
 
     script:
+    // omit --dataset flag entirely if dataset is empty
+    def datasetFlag = dataset ? "--dataset '${dataset}'" : ''
     """
-    adt ${config} --upload --platform NEXTFLOW --run_id ${workflow.runName} --dataset '${dataset}'
+    adt ${config} --upload --platform NEXTFLOW --run_id ${workflow.runName} ${datasetFlag}
     """
 
 }
@@ -31,9 +33,12 @@ process AGORA_DATA_RUN {
 workflow {
 
     if (params.dataset) {
-        datasets_ch = Channel.of(params.dataset)
+        // split comma-separated dataset names (handles optional spaces) into separate channel items
+        datasets_ch = Channel.of(params.dataset.split(',\\s*'))
     } else {
+        // fetch and parse the YAML config file
         def yaml = new Yaml().load(new URL(params.config).text)
+        // extract each dataset name and emit as separate channel items
         datasets_ch = Channel.from(yaml.datasets.collect { it.keySet().first() })
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,11 +37,17 @@ profiles {
         params {
             config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/model_ad_preprod.yaml"
         }
+        process {
+            memory = { 64.GB * task.attempt }
+        }
     }
 
     model_ad_prod {
         params {
             config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/model_ad_prod.yaml"
+        }
+        process {
+            memory = { 64.GB * task.attempt }
         }
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,34 +23,27 @@ profiles {
 
     agora_preprod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/agora_preprod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/agora_preprod.yaml"
         }
     }
 
     agora_prod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/agora_prod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/agora_prod.yaml"
         }
     }
 
     model_ad_preprod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/model_ad_preprod.yaml"
-        }
-        process {
-            memory = { 64.GB * task.attempt }
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/model_ad_preprod.yaml"
         }
     }
 
     model_ad_prod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/model_ad_prod.yaml"
-        }
-        process {
-            memory = { 64.GB * task.attempt }
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/model_ad_prod.yaml"
         }
     }
-
 
     debug {
         process {

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,6 +8,9 @@ process {
 params {
     config = null
     dataset = ''
+    large_memory_datasets = 'rna_de_individual,rna_de_aggregate'
+    large_memory_gb = 64
+    default_memory_gb = 32
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,25 +23,25 @@ profiles {
 
     agora_preprod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/agora_preprod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/agora_preprod.yaml"
         }
     }
 
     agora_prod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/agora_prod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/agora_prod.yaml"
         }
     }
 
     model_ad_preprod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/model_ad_preprod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/model_ad_preprod.yaml"
         }
     }
 
     model_ad_prod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/model_ad_prod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/ag-2122-combined/configs/model_ad_prod.yaml"
         }
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,6 +10,12 @@ params {
     dataset = ''
 }
 
+// fix transient timeout 
+env {
+    AWS_METADATA_SERVICE_TIMEOUT = 5
+    AWS_METADATA_SERVICE_NUM_ATTEMPTS = 3
+}
+
 profiles {
 
     docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,12 +10,6 @@ params {
     dataset = ''
 }
 
-// fix transient timeout 
-env {
-    AWS_METADATA_SERVICE_TIMEOUT = 5
-    AWS_METADATA_SERVICE_NUM_ATTEMPTS = 3
-}
-
 profiles {
 
     docker {

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,25 +23,25 @@ profiles {
 
     agora_preprod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/agora_preprod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/agora_preprod.yaml"
         }
     }
 
     agora_prod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/agora_prod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/agora_prod.yaml"
         }
     }
 
     model_ad_preprod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/model_ad_preprod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/model_ad_preprod.yaml"
         }
     }
 
     model_ad_prod {
         params {
-            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/dev/configs/model_ad_prod.yaml"
+            config = "https://raw.githubusercontent.com/Sage-Bionetworks/agora-data-tools/refs/heads/jbritton/MG-761/configs/model_ad_prod.yaml"
         }
     }
 


### PR DESCRIPTION
# Background and motivation
See: https://sagebionetworks.jira.com/browse/AG-2137

# Problem 
The container timed out after 6 hours of run because of memory for big datasets `rna_de_aggregate` (over 600K rows) and `rna_de_individual`(over 700K rows). See error below (see full run [here](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/agora-project/watch/1hBVkeedyLGVI7/v2/logs)) 
```
The exit status of the task that caused the workflow execution to fail was: 137

Error executing process > 'AGORA_DATA_RUN'

Caused by:
  Essential container in task exited - OutOfMemoryError: Container killed due to memory usage


Command executed:

  adt model_ad_preprod.yaml --upload --platform NEXTFLOW --run_id stupefied_waddington
```
Also one task could get cancelled based on the default error strategy (see [here](https://docs.seqera.io/nextflow/reference/process#errorstrategy))

# Solution
* Define large datasets. For big datasets, use 64 GB of memory
<img width="1205" height="610" alt="Screenshot 2026-06-16 at 3 43 46 PM" src="https://github.com/user-attachments/assets/78092821-2b42-4615-acfd-aa8f64ea65d6" />

* Run tasks in parallel 
* Make sure that datasets can be seen in "tag" column
<img width="739" height="123" alt="Screenshot 2026-06-16 at 3 22 12 PM" src="https://github.com/user-attachments/assets/0ee86327-78ee-40e6-911f-55424aacac78" />

* Make sure that if one task fails, the pipeline reports failure, but the processing of other tasks won't be stopped
# Test
* See [here](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/agora-project/watch/32WOF4fiFDlI1J/v2/tasks)
* Made sure that `--dataset` flag is still working when users pass in selected dataset 

